### PR TITLE
Moving to new coordinates of mockserver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <spotless.version>2.17.4</spotless.version>
         <testcontainers.version>1.17.6</testcontainers.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <mockserver-netty.version>5.13.2</mockserver-netty.version>
+        <mockserver-netty.version>5.14.0</mockserver-netty.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/test/java/com/sivalabs/bookstore/orderservice/common/AbstractIntegrationTest.java
+++ b/src/test/java/com/sivalabs/bookstore/orderservice/common/AbstractIntegrationTest.java
@@ -37,7 +37,7 @@ public abstract class AbstractIntegrationTest {
             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.3.0"));
     protected static final MockServerContainer mockServer =
             new MockServerContainer(
-                    DockerImageName.parse("jamesdbloom/mockserver:mockserver-5.13.2"));
+                    DockerImageName.parse("mockserver/mockserver:mockserver-5.14.0"));
 
     protected static MockServerClient mockServerClient;
 


### PR DESCRIPTION
docker coordinates have permanently move to newer one, hence using them.

Thanks for this new concept, all these days I'm using wirework with more work